### PR TITLE
Fix character input prompt on login button click

### DIFF
--- a/html/src/classes/apiLogin.js
+++ b/html/src/classes/apiLogin.js
@@ -374,14 +374,7 @@ export default class extends baseClass {
                                                                     .saveCredentials,
                                                             cipher: pwd
                                                         }).then(() => {
-                                                            this.loginForm.username =
-                                                                '';
-                                                            this.loginForm.password =
-                                                                '';
-                                                            this.loginForm.endpoint =
-                                                                '';
-                                                            this.loginForm.websocket =
-                                                                '';
+                                                            this.$refs.loginForm.resetFields();
                                                         });
                                                     });
                                             });
@@ -399,10 +392,7 @@ export default class extends baseClass {
                                 saveCredentials: this.loginForm.saveCredentials
                             })
                                 .then(() => {
-                                    this.loginForm.username = '';
-                                    this.loginForm.password = '';
-                                    this.loginForm.endpoint = '';
-                                    this.loginForm.websocket = '';
+                                    this.$refs.loginForm.resetFields();
                                 })
                                 .finally(() => {
                                     this.loginForm.loading = false;


### PR DESCRIPTION
When users click the login button, the username/password will be cleared. Incorrect character prompts will be displayed. To resolve this, el-form.resetFields should be triggered when the login button is clicked.